### PR TITLE
Give temperature as a keyword argument

### DIFF
--- a/app.py
+++ b/app.py
@@ -15,7 +15,7 @@ def generate(the_prompt, the_model):
     tokens = []
     skip = 0
 
-    for (token, prob), n in zip(generate_step(mx.array(tokenizer.encode(the_prompt)), the_model, temperature),
+    for (token, prob), n in zip(generate_step(mx.array(tokenizer.encode(the_prompt)), the_model, temp=temperature),
                                 range(context_length)):
 
         if token == tokenizer.eos_token_id:


### PR DESCRIPTION
This PR fixes the problem when launching app.py and then send a message as follows:
```
TypeError: generate_step() takes 2 positional arguments but 3 were given
Traceback:
File "/Users/shunta/.linuxbrew/Caskroom/miniconda/base/envs/mlx/lib/python3.11/site-packages/streamlit/runtime/scriptrunner/exec_code.py", line 88, in exec_func_with_error_handling
    result = func()
             ^^^^^^
File "/Users/shunta/.linuxbrew/Caskroom/miniconda/base/envs/mlx/lib/python3.11/site-packages/streamlit/runtime/scriptrunner/script_runner.py", line 579, in code_to_exec
    exec(code, module.__dict__)
File "/Users/shunta/Codes/mlx-ui/app.py", line 227, in <module>
    show_chat(st.session_state["prompt"], st.session_state["continuation"])
File "/Users/shunta/Codes/mlx-ui/app.py", line 53, in show_chat
    for chunk in generate(the_prompt, model):
File "/Users/shunta/Codes/mlx-ui/app.py", line 18, in generate
    for (token, prob), n in zip(generate_step(mx.array(tokenizer.encode(the_prompt)), the_model, temperature),
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

The temperature argument seems to be necessarily given to `generate_step()` as a keyword argument.